### PR TITLE
Fixes incorrectly calculated bandInc

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ function createGeometry(options, positions, cells) {
     var radDist = o.endRadian - o.startRadian;
     var numSlices = Math.floor(Math.abs(radDist) / (Math.PI * 2) * o.numSlices);
     var radInc = radDist / numSlices;
-    var bandInc = (o.outerRadius - o.innerRadius) / o.numBands;
+    var numBandIncs = (o.numBands == 1) ? 1 : o.numBands - 1;
+    var bandInc = (o.outerRadius - o.innerRadius) / numBandIncs;
     var cRad, x, y, z, cRadius, curSlideIdx, prevSlideIdx;
 
   for(var i = 0, len = numSlices; i <= len; i++) {


### PR DESCRIPTION
Fix for incorrectly calculated `bandInc` resulting in ring never reaching the outer radius.

E.g. with `innerRadius=0.5` and `outerRadius=1.0` your `bandInc` was `0.25` instead of `0.5` so the outer edge ended up at `0.75` instead of `1.0`.

I think this could happen as `numBands` parameter explained as "subdivision from inside out" is confusing. For `numBands=2` yes we get two bands / edges, but only 1 subdivision / slice. 

<img width="375" alt="screen shot 2016-01-29 at 14 39 00" src="https://cloud.githubusercontent.com/assets/171001/12678431/8c10a754-c696-11e5-8dd8-d82f14feefd3.png">
